### PR TITLE
Stop adding Description

### DIFF
--- a/src/AzureSignTool/Program.cs
+++ b/src/AzureSignTool/Program.cs
@@ -295,7 +295,7 @@ namespace AzureSignTool
                                 return (state.succeeded + 1, state.failed);
                             }
 
-                            var result = signer.SignFile(filePath, Description, SignDescriptionUrl, performPageHashing, logger, appendSignature);
+                            var result = signer.SignFile(filePath, null, SignDescriptionUrl, performPageHashing, logger, appendSignature);
                             switch (result)
                             {
                                 case COR_E_BADIMAGEFORMAT:


### PR DESCRIPTION
fixes #257

This code was adding the AzureSignTool project description to the signed file. Sending null allows the codesigning to reuse the existing description.